### PR TITLE
BREAKING: Rewrite role to manage production certificates too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,15 @@
 ---
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ome-ansible-molecule-dependencies
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-Nginx SSL Self-Signed
-=====================
+SSL Certificates
+================
 
-Generate self-signed SSL certificates for Nginx, for internal testing.
+Manage SSL certificates for web-servers.
+
+Optionally generate self-signed SSL certificates for internal testing.
+
 
 Role Variables
 --------------
@@ -9,14 +12,37 @@ Role Variables
 Defaults: `defaults/main.yml`
 
 Optional variables:
+- `ssl_certificate_path`: Server path to SSL certificate
+- `ssl_certificate_key_path`: Server path to SSL certificate key
+- `ssl_certificate_combined_path`: Server path to SSL combined certificate and key (e.g. for Haproxy), set to empty to disable
+- `ssl_certificate_content`: Text content of the certificate, for instance from vault
+- `ssl_certificate_key_content`: Text content of the certificate key
+- `ssl_certificate_selfsigned_create`: Create a self-signed certificate if necessary, default `True`
+- `ssl_certificate_selfsigned_subject`: Self-signed certificate subject
+- `ssl_certificate_selfsigned_days`: Self-signed certificate validity (days)
 
-- `nginx_ssl_certificate_subject`: Certificate subject
-- `nginx_ssl_certificate_days`: Certificate validity, default 365 days
-- `nginx_ssl_certificate`: Server path to SSL certificate
-- `nginx_ssl_certificate_key`: Server path to SSL certificate key
 
-Note this role does not configure Nginx for SSL, nor does it restart Nginx.
+Note this role does not configure or restart any webserver for SSL.
 This should be handled elsewhere.
+
+
+Example Playbooks
+-----------------
+
+Create a self-signed certificate with defaults:
+
+    - hosts: all
+      roles:
+        - role: ssl-certificate
+
+Install certificates stored in Ansible vault:
+
+    - hosts: all
+      roles:
+        - role: ssl-certificate
+          ssl_certificate_content: "{{ vault_certificate }}"
+          ssl_certificate_key_content: "{{ vault_certificate_key }}"
+          ssl_certificate_selfsigned_create: False
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Create a self-signed certificate with defaults:
       roles:
         - role: ssl-certificate
 
-Install certificates stored in Ansible vault:
+Install certificates stored locally on machine running Ansible:
 
     - hosts: all
       roles:
         - role: ssl-certificate
-          ssl_certificate_content: "{{ vault_certificate }}"
-          ssl_certificate_key_content: "{{ vault_certificate_key }}"
+          ssl_certificate_content: "{{ lookup('file', '/path/to/server.crt') }}"
+          ssl_certificate_key_content: "{{ lookup('file', '/path/to/server.key') }}"
           ssl_certificate_selfsigned_create: False
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,17 +1,26 @@
 ---
-# defaults file for roles/nginx-ssl-selfsigned
-
-# Certificate subject
-nginx_ssl_certificate_subject: "/C=UK/ST=Scotland/L=Dundee/O=OME/CN={{ ansible_fqdn }}"
-
-# Certificate validity (days)
-nginx_ssl_certificate_days: 365
+# defaults file for roles/ssl-certificates
 
 # Server path to SSL certificate
-nginx_ssl_certificate: /etc/nginx/ssl/server.crt
+ssl_certificate_path: /etc/ssl/server.crt
 
 # Server path to SSL certificate key
-nginx_ssl_certificate_key: /etc/nginx/ssl/server.key
+ssl_certificate_key_path: /etc/ssl/server.key
 
-# Systemd doesn't work inside Docker
-runningindocker: False
+# Server path to SSL combined certificate and key, set to empty to disable
+ssl_certificate_combined_path: /etc/ssl/combined.pem
+
+# Text content of the certificate
+ssl_certificate_content: ''
+
+# Text content of the certificate key
+ssl_certificate_key_content: ''
+
+# Create a self-signed certificate if necessary
+ssl_certificate_selfsigned_create: True
+
+# Certificate subject
+ssl_certificate_selfsigned_subject: "/C=UK/ST=Scotland/L=Dundee/O=OME/CN={{ ansible_fqdn }}"
+
+# Certificate validity (days)
+ssl_certificate_selfsigned_days: 365

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: ome-devel@lists.openmicroscopy.org.uk
-  description: Generate self-signed SSL certificates for Nginx
+  description: Manage SSL certificates for web-servers
   company: Open Microscopy Environment
   license: BSD
   min_ansible_version: 2.1

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: ssl-certificate
+
+docker:
+  containers:
+  - name: ssl-certificate
+    image: centos
+    image_version: 7
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,5 @@
+---
+
+- hosts: all
+  roles:
+    - role: ansible-role-nginx-ssl-selfsigned

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,25 +1,74 @@
 ---
-# tasks file for roles/nginx-ssl-selfsigned
+# tasks file for roles/ssl-certificate
 
-- name: system packages | install openssl
+- name: ssl certificate | install openssl
   become: yes
   yum:
     name: openssl
     state: present
 
-- name: nginx | create certificates directory
+- name: ssl certificate | create certificates directory
   become: yes
   file:
     path: "{{ item | dirname }}"
     state: directory
   with_items:
-    - "{{ nginx_ssl_certificate }}"
-    - "{{ nginx_ssl_certificate_key }}"
+    - "{{ ssl_certificate_path }}"
+    - "{{ ssl_certificate_key_path }}"
 
+# Create from content of variable e.g. from vault
+
+- name: ssl certificate | write SSL certificate
+  become: yes
+  copy:
+    content: "{{ ssl_certificate_content }}"
+    dest: "{{ ssl_certificate_path }}"
+    mode: 0400
+  no_log: True
+  when: not ssl_certificate_selfsigned_create
+
+- name: ssl certificate | write SSL certificate key
+  become: yes
+  copy:
+    content: "{{ ssl_certificate_key_content }}"
+    dest: "{{ ssl_certificate_key_path }}"
+    mode: 0400
+  no_log: True
+  when: not ssl_certificate_selfsigned_create
+
+# Self-signed
 # http://serialized.net/2013/04/simply-generating-self-signed-ssl-certs-with-ansible/
-- name: nginx | generate self-signed SSL certificate
+
+- name: ssl certificate | generate self-signed SSL certificate
   become: yes
   command:
-    openssl req -new -nodes -x509 -subj "{{ nginx_ssl_certificate_subject }}" -days {{ nginx_ssl_certificate_days }} -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -extensions v3_ca
+    openssl req -new -nodes -x509 -subj "{{ ssl_certificate_selfsigned_subject }}" -days {{ ssl_certificate_selfsigned_days }} -keyout {{ ssl_certificate_key_path }} -out {{ ssl_certificate_path }} -extensions v3_ca
   args:
-    creates: "{{ nginx_ssl_certificate }}"
+    # Don't overwrite existing certificate
+    creates: "{{ ssl_certificate_path }}"
+  when: ssl_certificate_selfsigned_create
+
+# Create combined certificate and key
+
+- name: ssl certificate | read certificate
+  become: yes
+  slurp:
+    src: "{{ ssl_certificate_path }}"
+  register: _ssl_certificate_content
+  no_log: True
+
+- name: ssl certificate | read certificate key
+  become: yes
+  slurp:
+    src: "{{ ssl_certificate_key_path }}"
+  register: _ssl_certificate_key_content
+  no_log: True
+
+- name: ssl certificate | write SSL combined certificate key
+  become: yes
+  copy:
+    content: "{{ _ssl_certificate_content.content | b64decode | trim }}\n{{ _ssl_certificate_key_content.content | b64decode }}"
+    dest: "{{ ssl_certificate_combined_path }}"
+    mode: 0400
+  no_log: True
+  when: "ssl_certificate_combined_path | length > 0"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,8 +23,7 @@
   copy:
     content: "{{ ssl_certificate_content }}"
     dest: "{{ ssl_certificate_path }}"
-    mode: 0400
-  no_log: True
+    mode: 0444
   when: not ssl_certificate_selfsigned_create
 
 - name: ssl certificate | write SSL certificate key
@@ -55,7 +54,6 @@
   slurp:
     src: "{{ ssl_certificate_path }}"
   register: _ssl_certificate_content
-  no_log: True
 
 - name: ssl certificate | read certificate key
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for roles/ssl-certificate
 
+- name: ssl certificate | check parameters
+  fail:
+    msg: ssl_certificate_content or ssl_certificate_key_content is empty
+  when: >-
+    not ssl_certificate_selfsigned_create and
+    ((ssl_certificate_content | length == 0) or
+    (ssl_certificate_key_content | length == 0))
+
 - name: ssl certificate | install openssl
   become: yes
   yum:

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-nginx-ssl-selfsigned

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,12 @@
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+def test_certificate(Command, Sudo):
+    with Sudo():
+        out = Command.check_output(
+            'openssl x509 -in /etc/ssl/server.crt -noout -subject')
+    assert out.startswith(
+        'subject= /C=UK/ST=Scotland/L=Dundee/O=OME/CN=')


### PR DESCRIPTION
At some point during a previous idr deployment @sbesson pointed out https://github.com/IDR/deployment/ uses a local copy of the production SSL certificates instead of vault/pass. This PR rewrites this role to handle both production certificates from vault/pass and self-signed.

In addition it creates a combined certificate required by Haproxy (this can be disabled).

Suggested new name for this role: `ssl-certificate` or `ssl-web-certificate(s)`