### PR TITLE
Add deprecation notes to the nginx-ssl-selfsigned role

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Nginx SSL Self-Signed
 
 Generate self-signed SSL certificates for Nginx, for internal testing.
 
+This role is now deprecated. Please us https://galaxy.ansible.com/openmicroscopy/ssl-certificate/ instead.
+
 Role Variables
 --------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,9 @@
 galaxy_info:
   author: ome-devel@lists.openmicroscopy.org.uk
-  description: Generate self-signed SSL certificates for Nginx
+  description: >
+    Generate self-signed SSL certificates for Nginx. This role is now
+    deprecated. Please use openmicroscopy.ssl-certificate
+    (https://galaxy.ansible.com/openmicroscopy/ssl-certificate/) instead.
   company: Open Microscopy Environment
   license: BSD
   min_ansible_version: 2.1


### PR DESCRIPTION
Superseded by https://github.com/openmicroscopy/ansible-role-ssl-certificate. Once merge, this repository should be made read-only.